### PR TITLE
Fixed Unmarshal error for ExternalTask.GetList

### DIFF
--- a/external-task.go
+++ b/external-task.go
@@ -379,7 +379,7 @@ func (e *ExternalTask) GetList(query map[string]string) ([]*ResExternalTask, err
 		return nil, err
 	}
 
-	if err := e.client.readJsonResponse(res, resp); err != nil {
+	if err := e.client.readJsonResponse(res, &resp); err != nil {
 		return nil, err
 	}
 
@@ -415,7 +415,7 @@ func (e *ExternalTask) GetListPost(query QueryGetListPost, firstResult, maxResul
 		return nil, err
 	}
 
-	if err := e.client.readJsonResponse(res, resp); err != nil {
+	if err := e.client.readJsonResponse(res, &resp); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Thanks for providing this go module.
I did however get into a little problem with it.

```golang
client := camunda_client_go.NewClient(camunda_client_go.ClientOptions{
	EndpointUrl: "http://localhost:8080/engine-rest",
	ApiUser: "demo",
	ApiPassword: "demo",
	Timeout: time.Second * 10,
})
tasks, err := client.ExternalTask.GetList(map[string]string{})
if err != nil {
	fmt.Println(err.Error())
}
```
The above code creates an error: `json: Unmarshal(non-pointer []*camunda_client_go.ResExternalTask)`

After a bit of debugging i found out that `client.readJsonResponse` is called in the `getList` method.
 `client.readJsonResponse` takes a pointer as second argument. In order to fix this passed the second parameter as reference, which fixed the error for me.

The same holds true for the `GetListPost` method.