### PR TITLE
allow null in retries on external task's response 

### DIFF
--- a/external-task.go
+++ b/external-task.go
@@ -35,8 +35,8 @@ type ResExternalTask struct {
 	ProcessInstanceId string `json:"processInstanceId"`
 	// The id of the tenant the external task belongs to
 	TenantId string `json:"tenantId"`
-	// The number of retries the task currently has left
-	Retries int `json:"retries"`
+	// The number of retries the task currently has left. Could be null in case retries were not set earlier and this is the first retry.
+	Retries *int `json:"retries"`
 	// A flag indicating whether the external task is suspended or not
 	Suspended bool `json:"suspended"`
 	// The id of the worker that possesses or possessed the most recent lock
@@ -192,8 +192,8 @@ type ResLockedExternalTask struct {
 	ProcessInstanceId string `json:"processInstanceId"`
 	// The id of the tenant the external task belongs to
 	TenantId string `json:"tenantId"`
-	// The number of retries the task currently has left
-	Retries int `json:"retries"`
+	// The number of retries the task currently has left. Could be null in case retries were not set earlier and this is the first retry.
+	Retries *int `json:"retries"`
 	// The id of the worker that possesses or possessed the most recent lock
 	WorkerId string `json:"workerId"`
 	// The priority of the external task


### PR DESCRIPTION
the camunda API responses with 'null' to indicate that the retries were not yet set on the external task
when the type of the retries was int it was not possible to distinguish this situation from the actual count of retries reaching zero
by using a pointer we are able to understand if this is the first retry and we can set the total number of retries or this is actually a case when the total number of retries was reached