### PR TITLE
Use PUT to update process variable instead of POST

### DIFF
--- a/process-instance.go
+++ b/process-instance.go
@@ -451,11 +451,7 @@ func (p *ProcessInstance) ModifyProcessVariables(id string, req ReqModifyProcess
 
 // UpdateProcessVariable sets a variable of a given process instance by id.
 func (p *ProcessInstance) UpdateProcessVariable(by QueryProcessInstanceVariableBy, req ReqProcessVariable) error {
-	res, err := p.client.doPostJson(by.String(), nil, req)
-	if res != nil {
-		res.Body.Close()
-	}
-	return err
+	return p.client.doPutJson(by.String(), nil, req)
 }
 
 // Delete deletes a running process instance by id.


### PR DESCRIPTION
I've tried to update a process variable and I was getting an error. I realised the client was using POST instead of PUT. I ended up using the Modify call at the end but here is the fix for posterity.
