### PR TITLE
Add correlation fields to ReqMessage

### DIFF
--- a/message.go
+++ b/message.go
@@ -19,9 +19,17 @@ type ReqMessage struct {
 	// A Boolean value that indicates whether the message should only be correlated to executions and process definitions which belong to no tenant or not.
 	// Value may only be true, as false is the default behavior.
 	// Must not be supplied in conjunction with a tenantId.
-	WithoutTenantId *bool `json:"withoutTenantId,omitempty"`
+	WithoutTenantId bool `json:"withoutTenantId,omitempty"`
 	// Used to correlate the message to the process instance with the given id.
 	ProcessInstanceId string `json:"processInstanceId,omitempty"`
+	// Used for correlation of process instances that wait for incoming messages.
+	// Has to be a JSON object containing key-value pairs that are matched against process instance variables during correlation.
+	// Each key is a variable name and each value a JSON variable value object with the following properties.
+	CorrelationKeys map[string]Variable `json:"correlationKeys,omitempty"`
+	// Local variables used for correlation of executions (process instances) that wait for incoming messages.
+	// Has to be a JSON object containing key-value pairs that are matched against local variables during correlation.
+	// Each key is a variable name and each value a JSON variable value object with the following properties.
+	LocalCorrelationKeys map[string]Variable `json:"localCorrelationKeys,omitempty"`
 	// A map of variables that is injected into the triggered execution or process instance after the message has been delivered.
 	// Each key is a variable name and each value a JSON variable value object with the following properties.
 	ProcessVariables *map[string]Variable `json:"processVariables,omitempty"`

--- a/message.go
+++ b/message.go
@@ -7,8 +7,23 @@ type Message struct {
 
 // ReqMessage a request to send a message
 type ReqMessage struct {
-	MessageName      string               `json:"messageName"`
-	BusinessKey      string               `json:"businessKey"`
+	// The name of the message to deliver.
+	MessageName string `json:"messageName,omitempty"`
+	// Used for correlation of process instances that wait for incoming messages.
+	// Will only correlate to executions that belong to a process instance with the provided business key.
+	BusinessKey string `json:"businessKey,omitempty"`
+	// Used to correlate the message for a tenant with the given id.
+	// Will only correlate to executions and process definitions which belong to the tenant.
+	// Must not be supplied in conjunction with a withoutTenantId.
+	TenantId string `json:"tenantIdIn,omitempty"`
+	// A Boolean value that indicates whether the message should only be correlated to executions and process definitions which belong to no tenant or not.
+	// Value may only be true, as false is the default behavior.
+	// Must not be supplied in conjunction with a tenantId.
+	WithoutTenantId *bool `json:"withoutTenantId,omitempty"`
+	// Used to correlate the message to the process instance with the given id.
+	ProcessInstanceId string `json:"processInstanceId,omitempty"`
+	// A map of variables that is injected into the triggered execution or process instance after the message has been delivered.
+	// Each key is a variable name and each value a JSON variable value object with the following properties.
 	ProcessVariables *map[string]Variable `json:"processVariables,omitempty"`
 }
 

--- a/message.go
+++ b/message.go
@@ -15,7 +15,7 @@ type ReqMessage struct {
 	// Used to correlate the message for a tenant with the given id.
 	// Will only correlate to executions and process definitions which belong to the tenant.
 	// Must not be supplied in conjunction with a withoutTenantId.
-	TenantId string `json:"tenantIdIn,omitempty"`
+	TenantId string `json:"tenantId,omitempty"`
 	// A Boolean value that indicates whether the message should only be correlated to executions and process definitions which belong to no tenant or not.
 	// Value may only be true, as false is the default behavior.
 	// Must not be supplied in conjunction with a tenantId.


### PR DESCRIPTION
We need more correlation fields in `ReqMessage` for our project. There are a few more fields not added by this PR, but since we are not using them, I did not test them, and thus I've preferred to left them out.